### PR TITLE
Pan/zoom: couple canvases 

### DIFF
--- a/src/GtkUtilities.jl
+++ b/src/GtkUtilities.jl
@@ -1,14 +1,10 @@
-VERSION >= v"0.4.0-dev+6521" && __precompile__()
+__precompile__()
 
 module GtkUtilities
 
 using Cairo, Gtk.ShortNames, Colors
 
-if VERSION < v"0.4.0-dev"
-    using Docile, Base.Graphics
-else
-    using Graphics
-end
+using Graphics
 
 export
     # Link
@@ -59,13 +55,13 @@ Base.copy!(c::Canvas, img) = copy!(getgc(c), img)
 image_surface{C<:Color}(img::AbstractArray{C}) = CairoImageSurface(reinterpret(UInt32, convert(Matrix{RGB24}, img)), Cairo.FORMAT_RGB24, flipxy=false)
 image_surface{C<:Colorant}(img::AbstractArray{C}) = CairoImageSurface(reinterpret(UInt32, convert(Matrix{ARGB32}, img)), Cairo.FORMAT_ARGB32, flipxy=false)
 
-@doc """
+"""
 Summary of features in GtkUtilities:
 
 - `rubberband_start`: initiate rubber band selection
 - `guidata`: associate user data with on-screen elements
 
 Each of these has detailed help available, e.g., `?guidata`.
-""" -> GtkUtilities
+""" GtkUtilities
 
 end # module

--- a/src/guidata.jl
+++ b/src/guidata.jl
@@ -61,6 +61,8 @@ end
 
 Base.setindex!{T}(wd::GUIData, val, ws::@compat(Tuple{T,Symbol})) = wd.data[ws[1],ws[2]] = val
 
+Base.haskey(wd::GUIData, key) = haskey(wd.data, key)
+
 function Base.get{T}(wd::GUIData, ws::@compat(Tuple{T,Symbol}), default; raw::Bool=false)
     d = get(wd.data, ws[1], empty_guidata)
     val = d == empty_guidata ? default : get(d, ws[2], default)

--- a/src/link.jl
+++ b/src/link.jl
@@ -167,6 +167,14 @@ function disconnect(val::AbstractState)
     end
 end
 
+function disconnect(val::AbstractState, c::Canvas)
+    index = findfirst(val.canvases, c)
+    if index != 0
+        deleteat!(val.canvases, index)
+    end
+    index
+end
+
 function Base.show(io::IO, w::LinkedWidget)
     print(io, "Linked ", typeof(w.widget).name.name, "(", get(w), ")")
     n = getproperty(w.widget, :name, ByteString)

--- a/src/link.jl
+++ b/src/link.jl
@@ -63,7 +63,7 @@ function Base.similar(s::State)
     if !isimmutable(v)
         v = copy(v)
     end
-    State(v, s.widgets, s.canvases)
+    State(v, copy(s.widgets), copy(s.canvases))
 end
 
 function set!{T}(state::State{T}, value)


### PR DESCRIPTION
This allows you to specify that two (or more) canvases should share the same pan/zoom information with `panzoom(c2, c1)`; when you zoom on one, it also zooms on the other(s). The relationship is symmetric. You can also decouple them again with `panzoom(c2)`.
